### PR TITLE
feat(homepage): add functionality to 'See About' button

### DIFF
--- a/src/routes/WhoWeAre.svelte
+++ b/src/routes/WhoWeAre.svelte
@@ -16,7 +16,7 @@
         </p>
         <div class="w-full text-center md:text-left">
             <Button>
-                <span>See About</span>
+                <a href="/about/">See About</a>
             </Button>
         </div>
     </div>


### PR DESCRIPTION
Implement navigation for the 'See About' button to link to the About page. Previously, this button had no functionality. Clicking it now redirects users to the About page.